### PR TITLE
Post/subscriptions

### DIFF
--- a/app/controllers/api/v1/customers/subscriptions_controller.rb
+++ b/app/controllers/api/v1/customers/subscriptions_controller.rb
@@ -3,4 +3,15 @@ class Api::V1::Customers::SubscriptionsController < ApplicationController
     customer = Customer.includes(:subscriptions).find(params[:customer_id])
     render json: SubscriptionSerializer.new(customer.subscriptions)
   end
+
+  def create
+    customer = Customer.find(params[:customer_id])
+    render json: SubscriptionSerializer.new(customer.subscriptions.create!(subscription_params)), status: 201
+  end
+
+  private
+
+  def subscription_params
+    params.permit(:tea_id, :price, :title, :frequency)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,10 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_response
+  rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
+
+  def render_unprocessable_entity_response(exception)
+    render json: ErrorSerializer.serialize_error(exception, :bad_request, 'Record Invalid'), status: :bad_request
+  end
 
   def render_not_found_response(exception)
     render json: ErrorSerializer.serialize_error(exception, :not_found, 'Record not Found'), status: :not_found

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,4 +3,7 @@ class Subscription < ApplicationRecord
   belongs_to :customer
 
   enum status: %i[active cancelled]
+
+  validates_numericality_of :frequency
+  validates_numericality_of :price
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :customers do
         scope module: :customers do
-          resources :subscriptions, only: [:index]
+          resources :subscriptions, only: [:index, :create]
         end
       end
     end

--- a/db/migrate/20230420163441_change_status_default_in_subscription.rb
+++ b/db/migrate/20230420163441_change_status_default_in_subscription.rb
@@ -1,0 +1,5 @@
+class ChangeStatusDefaultInSubscription < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :subscriptions, :status, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_20_012919) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_20_163441) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_20_012919) do
     t.bigint "tea_id", null: false
     t.bigint "customer_id", null: false
     t.bigint "price"
-    t.integer "status"
+    t.integer "status", default: 0
     t.integer "frequency"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/ci_sample_spec.rb
+++ b/spec/ci_sample_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'example' do
-  it 'should pass' do
-    expect(true).to be true
-  end
-end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -5,4 +5,9 @@ RSpec.describe Subscription, type: :model do
     it { should belong_to :tea }
     it { should belong_to :customer }
   end
+
+  describe 'validations' do
+    it { should validate_numericality_of :frequency }
+    it { should validate_numericality_of :price }
+  end
 end

--- a/spec/requests/api/v1/customers/subscriptions/subscriptions_request_spec.rb
+++ b/spec/requests/api/v1/customers/subscriptions/subscriptions_request_spec.rb
@@ -61,7 +61,62 @@ RSpec.describe 'Customer Subscription API' do
 
       get '/api/v1/customers/9123941234/subscriptions'
 
+      error_data = JSON.parse(response.body, symbolize_names: true)
+
       expect(response.status).to eq(404)
+      expect(error_data[:message]).to eq 'Record not Found'
+      expect(error_data[:errors][0][:detail]).to eq "Couldn't find Customer with 'id'=9123941234"
+    end
+  end
+
+  describe 'POST customer subscription' do
+
+    before(:each) do
+      @customer = create(:customer)
+    end
+
+    it 'can create a new subscription for a customer' do
+      tea = create(:tea)
+      sub_params = {
+        tea_id: tea.id,
+        titel: 'Green Tea Subscription',
+        price: 5.00,
+        frequency: 2
+      }
+
+      post "/api/v1/customers/#{@customer.id}/subscriptions", params: JSON.generate(sub_params)
+
+      sub_data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+      expect(sub_data[:data][:id]).to be_a String
+      expect(sub_data[:data][:type]).to eq 'subscription'
+      expect(sub_data[:data][:attributes][:title]).to be_a String
+      expect(sub_data[:data][:attributes][:price]).to be_a Numeric
+      expect(sub_data[:data][:attributes][:frequency]).to be_a Numeric
+      expect(sub_data[:data][:attributes][:status]).to eq 'active'
+    end
+
+    it 'can return a 404 if the given customer doesnt exist' do
+
+      post '/api/v1/customers/1231348932/subscriptions'
+
+      error_data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.status).to eq 404
+      expect(error_data[:message]).to eq '?'
+      expect(error_data[:errors]).to eq '?'
+    end
+
+    it 'can return a 422 if invalid subscription data is given' do
+
+      post "/api/v1/customers/#{@customer.id}/subscriptions"
+
+      error_data = JSON.parse(response.body, symbolize_names: true)
+      expect(response.status).to eq 404
+      expect(error_data[:message]).to eq '?'
+      expect(error_data[:errors]).to eq '?'
     end
   end
 end


### PR DESCRIPTION
Issue #11 

Summary: Exposes the `POST api/v1/customers/:customer_id/subscriptions` endpoint. Allows a user to create a subscription to a tea for a customer. Adds default value for status and validations for numeric fields for subscription model. 